### PR TITLE
:ambulance: Forward client routing in production

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -1,6 +1,8 @@
-import express from "express";
 import dotenv from "dotenv";
 dotenv.config();
+
+import path from "path";
+import express from "express";
 
 const { PORT = 3000 } = process.env;
 
@@ -11,6 +13,11 @@ app.use("/storybook", express.static("dist/storybook"));
 
 // Serve app production bundle
 app.use(express.static("dist/app"));
+
+// Handle client routing, return all requests to the app
+app.get("*", (_req, res) => {
+  res.sendFile(path.join(__dirname, "app/index.html"));
+});
 
 app.listen(PORT, () => {
   console.log(`Boilerplate listening at http://localhost:${PORT}`);


### PR DESCRIPTION
On production (Heroku deployment or npm start), it's not possible to directly go to routes like /register.